### PR TITLE
Configured JVM parameters & Can prompt for uncommitted changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ version = versionMajor + "." + versionMinor + versionQualifier
 
 mainClassName = 'org.polypheny.qtf.Main'
 
+applicationDefaultJvmArgs = [
+    '-Dfile.encoding=UTF-8'
+]
+
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
     sourceCompatibility = '11'

--- a/src/main/java/org/polypheny/qtf/Controller.java
+++ b/src/main/java/org/polypheny/qtf/Controller.java
@@ -20,6 +20,8 @@ package org.polypheny.qtf;
 import java.awt.Desktop;
 import java.io.IOException;
 import javafx.application.Platform;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
@@ -37,9 +39,19 @@ public class Controller extends QueryInterface {
     private Label feedback;
     @FXML
     private TextField tableId;
+    @FXML
+    private Label tag;
+
+    @FXML
+    public static BooleanProperty booleanVar = new SimpleBooleanProperty(false);
 
     public Controller() {
         super();
+    }
+
+    public void initialize() {
+        // Bind a Boolean variable to the visible property of tag
+        tag.visibleProperty().bindBidirectional(booleanVar);
     }
 
     @FXML
@@ -87,6 +99,7 @@ public class Controller extends QueryInterface {
             } else {
                 printFeedback( String.format( "The commit was successful. %d rows were affected.", result.affectedRows ) );
             }
+            booleanVar.set( false );
         }
     }
 

--- a/src/main/java/org/polypheny/qtf/fuse/ResultFS.java
+++ b/src/main/java/org/polypheny/qtf/fuse/ResultFS.java
@@ -30,6 +30,7 @@ import kong.unirest.Unirest;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.polypheny.qtf.Controller;
 import org.polypheny.qtf.QTFConfig;
 import org.polypheny.qtf.web.BatchUpdateRequest;
 import org.polypheny.qtf.web.BatchUpdateRequest.Update;
@@ -289,6 +290,7 @@ public class ResultFS extends FuseStubFS {
                 contents.put( bytesToWrite );
                 contents.position( 0 ); // Rewind
             }
+            Controller.booleanVar.set(true);
             return (int) bufSize;
         }
 
@@ -399,6 +401,7 @@ public class ResultFS extends FuseStubFS {
         if ( parent instanceof ResultDirectory ) {
             String lastComponent = getLastComponent( path );
             ((ResultDirectory) parent).mkfile( lastComponent, result != null && result.containsColumn( lastComponent ) );
+            Controller.booleanVar.set(true);
             return 0;
         }
         return -ErrorCodes.ENOENT();
@@ -447,6 +450,7 @@ public class ResultFS extends FuseStubFS {
         ResultPath parent = getParentPath( path );
         if ( parent instanceof ResultDirectory ) {
             ((ResultDirectory) parent).mkdir( getLastComponent( path ) );
+            Controller.booleanVar.set(true);
             return 0;
         }
         return -ErrorCodes.ENOENT();
@@ -517,6 +521,7 @@ public class ResultFS extends FuseStubFS {
         }
         p.rename( newName.substring( newName.lastIndexOf( "/" ) ) );
         ((ResultDirectory) newParent).add( p );
+        Controller.booleanVar.set(true);
         return 0;
     }
 
@@ -545,6 +550,7 @@ public class ResultFS extends FuseStubFS {
             return -ErrorCodes.EISDIR();
         }
         ((ResultFile) p).truncate( offset );
+        Controller.booleanVar.set(true);
         return 0;
     }
 
@@ -560,6 +566,7 @@ public class ResultFS extends FuseStubFS {
         } else {
             p.delete();
         }
+        Controller.booleanVar.set(true);
         return 0;
     }
 

--- a/src/main/java/org/polypheny/qtf/web/SocketClient.java
+++ b/src/main/java/org/polypheny/qtf/web/SocketClient.java
@@ -25,6 +25,7 @@ import java.util.TimerTask;
 import lombok.extern.slf4j.Slf4j;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
+import org.polypheny.qtf.Controller;
 import org.polypheny.qtf.QTFConfig;
 import org.polypheny.qtf.QueryInterface;
 import org.polypheny.qtf.fuse.ResultFS;
@@ -113,6 +114,7 @@ public class SocketClient extends WebSocketClient {
             myFuse.add( dir );
         }
         myFuse.setResult( result );
+        Controller.booleanVar.set( false );
     }
 
     @Override

--- a/src/main/resources/fxml/sample.fxml
+++ b/src/main/resources/fxml/sample.fxml
@@ -56,6 +56,7 @@
                     </children>
                 </FlowPane>
                 <Label id="feedback" fx:id="feedback" wrapText="true" GridPane.rowIndex="1"/>
+                <Label id="tag" text="Data changed but not committed" fx:id="tag" wrapText="true" GridPane.rowIndex="2"/>
             </children>
             <padding>
                 <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>


### PR DESCRIPTION
1. Can open folders on Windows

After changing the configuration, you can open the file on Windows

This should be the solution to the problem of not being able to open files in Windows

 [Corresponding issue](https://github.com/polypheny/Polypheny-DB/issues/297)

2. Added the function to prompt for uncommitted changes.  

You will be prompted when changing data, deleting files, adding files, renaming, etc. When the changes are submitted, or a new query is replaced, the prompt will disappear.

[Corresponding issue](https://github.com/polypheny/Polypheny-DB/issues/305)

![qtf-ezgif com-video-to-gif-converter](https://github.com/polypheny/Query-to-File/assets/90972647/b930e1ff-d209-4793-84e0-3ce3e62711b8)
